### PR TITLE
Update categorical.sql

### DIFF
--- a/categorical/categorical.sql
+++ b/categorical/categorical.sql
@@ -157,7 +157,7 @@ as declare
     qstr text;
 begin
     qstr = 'select chisq_agg(NumRows, NumCols, Cell, RowTotal, ColTotal) from (';
-    qstr = concat(qstr,' with ';
+    qstr = concat(qstr,' with ');
     qstr = concat(qstr,' foo as ( select * from ', tbl, ' where ', rowvar, ' is not null and ', colvar, ' is not null),');
     qstr = concat(qstr,' cell_counts as ( select ', rowvar, ' as "Row",', colvar, ' as "Col", sum(',grpvar,') as "Cell" ');
     qstr = concat(qstr,' from foo group by ', rowvar, ', ', colvar, '),');


### PR DESCRIPTION
https://github.com/singlestore-labs/singlestoredb-statistics/blob/b382a1341ab6d82699f0e2dc70a38e57e8ff169f/categorical/categorical.sql#L160

This line is missing a bracket:

`qstr = concat(qstr,' with ';`

The correct form should be:

`qstr = concat(qstr,' with ');`